### PR TITLE
Remove hard dependency on default

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -113,7 +113,7 @@ multidimensions.register_dimension=function(name,def,self)
 		node.description = node.description or		"Teleport to dimension " .. name
 		node.tiles = node.tiles or			{"default_steel_block.png"}
 		node.groups = node.groups or		{cracky=2,not_in_creative_inventory=multidimensions.craftable_teleporters and 0 or 1}
-		node.sounds = node.sounds or		default.node_sound_wood_defaults()
+		node.sounds = node.sounds or ( default and default.node_sound_wood_defaults() ) or nil
 		node.after_place_node = function(pos, placer, itemstack)
 			local meta=minetest.get_meta(pos)
 			meta:set_string("owner",placer:get_player_name())
@@ -317,7 +317,7 @@ minetest.register_node("multidimensions:bedrock", {
 	sunlight_propagates = true,
 	drop = "",
 	diggable = false,
-	sounds = default.node_sound_stone_defaults(),
+	sounds = (default and default.node_sound_stone_defaults() ) or nil,
 })
 
 minetest.register_node("multidimensions:blocking", {
@@ -365,7 +365,7 @@ minetest.register_node("multidimensions:teleporter0", {
 	tiles = {"default_steel_block.png","default_steel_block.png","default_mese_block.png^[colorize:#1e6600cc"},
 	groups = {choppy=2,oddly_breakable_by_hand=1},
 	is_ground_content = false,
-	sounds = default.node_sound_wood_defaults(),
+	sounds = (default and default.node_sound_wood_defaults()) or nil,
 	after_place_node = function(pos, placer, itemstack)
 		local meta=minetest.get_meta(pos)
 		meta:set_string("owner",placer:get_player_name())
@@ -394,7 +394,7 @@ minetest.register_node("multidimensions:teleporterre", {
 	tiles = {"default_steel_block.png"},
 	groups = {cracky=3},
 	is_ground_content = false,
-	sounds = default.node_sound_wood_defaults(),
+	sounds = (default and default.node_sound_wood_defaults()) or nil,
 	drop = "default:cobble",
 	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
 		local p = minetest.get_meta(pos):get_string("pos")

--- a/api.lua
+++ b/api.lua
@@ -117,7 +117,7 @@ multidimensions.register_dimension=function(name,def,self)
 
 	if def.teleporter then
 		node.description = node.description or		"Teleport to dimension " .. name
-		node.tiles = node.tiles or			{"default_steel_block.png"}
+		node.tiles = node.tiles or ( minetest.get_modpath("default") and {"default_steel_block.png"}) or "^[colorize:#222222"
 		node.groups = node.groups or		{cracky=2,not_in_creative_inventory=multidimensions.craftable_teleporters and 0 or 1}
 		node.sounds = node.sounds or ( default and default.node_sound_wood_defaults() ) or nil
 		node.after_place_node = function(pos, placer, itemstack)
@@ -159,7 +159,7 @@ multidimensions.register_dimension=function(name,def,self)
 				end
 			}
 		}
-		minetest.register_node("multidimensions:teleporter_" .. name, node)
+		minetest.register_node(":multidimensions:teleporter_" .. name, node)
 
 		if multidimensions.craftable_teleporters and craft then
 			minetest.register_craft({

--- a/api.lua
+++ b/api.lua
@@ -4,7 +4,6 @@ if minetest.get_modpath("default") then
 	bedrock_tiles = {"default_stone.png","default_cloud.png","default_stone.png","default_stone.png","default_stone.png","default_stone.png",}
 end
 
-
 multidimensions.register_dimension=function(name,def,self)
 
 	local y = multidimensions.first_dimensions_appear_at
@@ -30,7 +29,7 @@ multidimensions.register_dimension=function(name,def,self)
 	def.terrain_density = def.terrain_density or	0.4
 	def.flatland = def.flatland
 	def.gravity = def.gravity or			1
-	
+
 	def.cave_threshold = def.cave_threshold or 0.1 --CBN 22/10/2022 Added cave threshold to dimension definition.
 	--def.sky = def.sky
 
@@ -43,7 +42,7 @@ multidimensions.register_dimension=function(name,def,self)
 	def.map.persist = def.map.persist or 0.7
 	def.map.lacunarity = def.map.lacunarity or 1
 	def.map.flags = def.map.flags or "absvalue"
-	
+
 	def.cavemap = def.cavemap or {} --CBN 22/10/2022 Added cave noise parameters to dimension definition
 	def.cavemap.offset = def.cavemap.offset or 0
 	def.cavemap.scale = def.cavemap.scale or 1
@@ -217,7 +216,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 		for z=minp.z,maxp.z do
 		for y=minp.y,maxp.y do
 			local id = area:index(minp.x,y,z)
-		for x=minp.x,maxp.x do	
+		for x=minp.x,maxp.x do
 			local den = math.abs(map[cindx]) - math.abs(height-y)/(depth*2) or 0
 			if y <= miny+bedrock_depth then
 				data[id] = bedrock
@@ -245,11 +244,11 @@ minetest.register_on_generated(function(minp, maxp, seed)
 			else
 				data[id] = air
 			end
-			
+
 			if y < ground_limit and y > miny + bedrock_depth and cavemap[cindx] <= cave_threshold then --CBN 22/10/2022 Cave carving
 				data[id] = air
 			end
-			
+
 			if d.on_generate then
 				data = d.on_generate(d.self,data,id,area,x,y,z) or data
 			end
@@ -261,7 +260,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 		end
 
 		local node_y = minp.y
-		
+
 		for i1,v1 in pairs(data) do
 			if i1%area.ystride == 0 then
 				node_y = node_y + 1

--- a/api.lua
+++ b/api.lua
@@ -366,63 +366,6 @@ minetest.register_on_chat_message(function(name, message)
 end)
 end
 
-
-minetest.register_node("multidimensions:teleporter0", {
-	description = "Teleport to dimension earth",
-	tiles = {"default_steel_block.png","default_steel_block.png","default_mese_block.png^[colorize:#1e6600cc"},
-	groups = {choppy=2,oddly_breakable_by_hand=1},
-	is_ground_content = false,
-	sounds = (default and default.node_sound_wood_defaults()) or nil,
-	after_place_node = function(pos, placer, itemstack)
-		local meta=minetest.get_meta(pos)
-		meta:set_string("owner",placer:get_player_name())
-		meta:set_string("infotext","Teleport to dimension earth")
-	end,
-	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
-		local owner=minetest.get_meta(pos):get_string("owner")
-		local pos2={x=pos.x,y=0,z=pos.z}
-		if minetest.is_protected(pos2, owner)==false then
-			multidimensions.move(player,pos2)
-		end
-	end,
-	mesecons = {effector = {
-		action_on = function (pos, node)
-		local owner=minetest.get_meta(pos):get_string("owner")
-		local pos2={x=pos.x,y=0,z=pos.z}
-		for i, ob in pairs(minetest.get_objects_inside_radius(pos, 5)) do
-			multidimensions.move(ob,pos2)
-		end
-		return false
-	end}},
-})
-
-minetest.register_node("multidimensions:teleporterre", {
-	description = "Teleport back",
-	tiles = {"default_steel_block.png"},
-	groups = {cracky=3},
-	is_ground_content = false,
-	sounds = (default and default.node_sound_wood_defaults()) or nil,
-	drop = "default:cobble",
-	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
-		local p = minetest.get_meta(pos):get_string("pos")
-		if p == "" then
-			minetest.remove_node(pos)
-			return
-		end
-		multidimensions.move(player,minetest.string_to_pos(p),nil,true)
-	end,
-	mesecons = {effector = {
-		action_on = function (pos, node)
-		local owner=minetest.get_meta(pos):get_string("owner")
-		local pos2={x=pos.x,y=0,z=pos.z}
-		for i, ob in pairs(minetest.get_objects_inside_radius(pos, 5)) do
-			multidimensions.move(ob,pos2)
-		end
-		return false
-	end}},
-})
-
-
 if multidimensions.limeted_nametag==true and minetest.settings:get_bool("unlimited_player_transfer_distance")~=false then
 	minetest.settings:set_bool("unlimited_player_transfer_distance",false)
 	minetest.settings:set_bool("player_transfer_distance",multidimensions.max_distance)

--- a/api.lua
+++ b/api.lua
@@ -1,3 +1,10 @@
+local bedrock_tiles = {"^[colorize:grey"}
+
+if minetest.get_modpath("default") then
+	bedrock_tiles = {"default_stone.png","default_cloud.png","default_stone.png","default_stone.png","default_stone.png","default_stone.png",}
+end
+
+
 multidimensions.register_dimension=function(name,def,self)
 
 	local y = multidimensions.first_dimensions_appear_at
@@ -311,7 +318,7 @@ end)
 
 minetest.register_node("multidimensions:bedrock", {
 	description = "Bedrock",
-	tiles = {"default_stone.png","default_cloud.png","default_stone.png","default_stone.png","default_stone.png","default_stone.png",},
+	tiles = bedrock_tiles,
 	groups = {unbreakable=1,not_in_creative_inventory = 1},
 	paramtype = "light",
 	sunlight_propagates = true,

--- a/dimensions.lua
+++ b/dimensions.lua
@@ -35,211 +35,209 @@ minetest.register_node("multidimensions:jungle_tree", {drawtype="airlike",groups
 minetest.register_node("multidimensions:aspen_tree", {drawtype="airlike",groups = {multidimensions_tree=1,not_in_creative_inventory=1},})
 minetest.register_node("multidimensions:acacia_tree", {drawtype="airlike",groups = {multidimensions_tree=1,not_in_creative_inventory=1},})
 
-if minetest.get_modpath("default") then
-	multidimensions.register_dimension("earthlike1",{
-		ground_ores = table.copy(plants),
-		stone_ores = table.copy(ores),
-		sand_ores={["default:clay"]={chunk=2,chance=5000}},
-		grass_ores={
-			["default:dirt_with_snow"]={chance=1,max_heat=20},
-		},
-		water_ores={
-			["default:ice"]={chance=1,max_heat=20},
-		},
-		node={description="Alternative earth"},
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:wood","default:mese","default:wood",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		}
-	})
+multidimensions.register_dimension("earthlike1",{
+	ground_ores = table.copy(plants),
+	stone_ores = table.copy(ores),
+	sand_ores={["default:clay"]={chunk=2,chance=5000}},
+	grass_ores={
+		["default:dirt_with_snow"]={chance=1,max_heat=20},
+	},
+	water_ores={
+		["default:ice"]={chance=1,max_heat=20},
+	},
+	node={description="Alternative earth"},
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:wood","default:mese","default:wood",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	}
+})
 
-	multidimensions.register_dimension("earthlike2",{
-		ground_ores = table.copy(plants),
-		stone_ores = table.copy(ores),
-		sand_ores={["default:clay"]={chunk=2,chance=5000}},
-		node={description="Alternative earth 2"},
-		map={spread={x=20,y=18,z=20}},
-		ground_limit=550,
-		gravity=0.5,
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:aspen_wood","default:mese","default:aspen_wood",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		}
-	})
+multidimensions.register_dimension("earthlike2",{
+	ground_ores = table.copy(plants),
+	stone_ores = table.copy(ores),
+	sand_ores={["default:clay"]={chunk=2,chance=5000}},
+	node={description="Alternative earth 2"},
+	map={spread={x=20,y=18,z=20}},
+	ground_limit=550,
+	gravity=0.5,
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:aspen_wood","default:mese","default:aspen_wood",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	}
+})
 
-	multidimensions.register_dimension("floatandlike",{
-		ground_ores = table.copy(plants),
-		stone_ores = table.copy(ores),
-		node={description="Alternative floatand"},
-		ground_limit=550,
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:dirt","default:mese","default:dirt",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		},
-		map={
-			spread={x=30,y=30,z=30},
-			octaves=3,
-			persist=0.2,
-			lacunarity=2,
-			flags="eased",
-		},
-		terrain_density=0.2,
-		enable_water=false,
-		self={
-			blocking="multidimensions:blocking",
-			killing = "multidimensions:killing",
-		},
-		on_generate=function(self,data,id,area,x,y,z)
-			if y <= self.dirt_start-70 then
-				data[id] = self.killing
-			elseif y <= self.dirt_start-100 then
-				data[id] = self.blocking
-			elseif y <= self.dirt_start+5 then
-				data[id] = self.air
-			else
-				return
-			end
-			return data
-		end,
-	})
-
+multidimensions.register_dimension("floatandlike",{
+	ground_ores = table.copy(plants),
+	stone_ores = table.copy(ores),
+	node={description="Alternative floatand"},
+	ground_limit=550,
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:dirt","default:mese","default:dirt",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	},
+	map={
+		spread={x=30,y=30,z=30},
+		octaves=3,
+		persist=0.2,
+		lacunarity=2,
+		flags="eased",
+	},
+	terrain_density=0.2,
+	enable_water=false,
+	self={
+		blocking="multidimensions:blocking",
+		killing = "multidimensions:killing",
+	},
+	on_generate=function(self,data,id,area,x,y,z)
+		if y <= self.dirt_start-70 then
+			data[id] = self.killing
+		elseif y <= self.dirt_start-100 then
+			data[id] = self.blocking
+		elseif y <= self.dirt_start+5 then
+			data[id] = self.air
+		else
+			return
+		end
+		return data
+	end,
+})
 
 
-	multidimensions.register_dimension("savana",{
-		ground_ores = {
-			["default:dry_shrub"]=50,
-			["default:dry_grass_4"]=10,
-			["multidimensions:acacia_tree"]=5000,
-			["multidimensions:jungle_tree"]=7000,
-		},
-		grass="default:dirt_with_dry_grass",
-		stone_ores = table.copy(ores),
-		sand_ores={["default:clay"]=100},
-		node={description="Savana"},
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:acacia","default:mese","default:acacia",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		}
-	})
 
-	multidimensions.register_dimension("cold",{
-		ground_ores = {
-			["default:snow"]=100,
-			["multidimensions:pine_treesnow"]=8000,
-		},
-		dirt="default:snowblock",
-		grass="default:snowblock",
-		water="default:ice",
-		stone="default:ice",
-		sand="default:ice",
-		node={description="cold"},
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:aspen_wood","default:mese","default:aspen_wood",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		}
-	})
+multidimensions.register_dimension("savana",{
+	ground_ores = {
+		["default:dry_shrub"]=50,
+		["default:dry_grass_4"]=10,
+		["multidimensions:acacia_tree"]=5000,
+		["multidimensions:jungle_tree"]=7000,
+	},
+	grass="default:dirt_with_dry_grass",
+	stone_ores = table.copy(ores),
+	sand_ores={["default:clay"]=100},
+	node={description="Savana"},
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:acacia","default:mese","default:acacia",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	}
+})
 
-	multidimensions.register_dimension("desert",{
-		dirt="default:desert_sand",
-		grass="default:desert_sand",
-		stone="default:desert_stone",
-		sand="default:desert_sand",
-		node={description="desert"},
-		enable_water=false,
-		gravity=0.4,
-		map={octaves=2,persist=0.3,lacunarity=2},
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:desert_stone","default:mese","default:desert_stone",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		},
-		sky={{r=219, g=168, b=117},"plain",{}},
-	})
+multidimensions.register_dimension("cold",{
+	ground_ores = {
+		["default:snow"]=100,
+		["multidimensions:pine_treesnow"]=8000,
+	},
+	dirt="default:snowblock",
+	grass="default:snowblock",
+	water="default:ice",
+	stone="default:ice",
+	sand="default:ice",
+	node={description="cold"},
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:aspen_wood","default:mese","default:aspen_wood",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	}
+})
 
-	multidimensions.register_dimension("hot",{
-		ground_ores = {
-			["fire:permanent_flame"]=10,
-		},
-		dirt="default:stone",
-		grass="default:stone",
-		sand="default:lava_source",
-		water="default:lava_source",
-		map={octaves=3,persist=0.6,lacunarity=2},
-		node={description="Hot"},
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:torch","default:mese","default:torch",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		}
-	})
+multidimensions.register_dimension("desert",{
+	dirt="default:desert_sand",
+	grass="default:desert_sand",
+	stone="default:desert_stone",
+	sand="default:desert_sand",
+	node={description="desert"},
+	enable_water=false,
+	gravity=0.4,
+	map={octaves=2,persist=0.3,lacunarity=2},
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:desert_stone","default:mese","default:desert_stone",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	},
+	sky={{r=219, g=168, b=117},"plain",{}},
+})
+
+multidimensions.register_dimension("hot",{
+	ground_ores = {
+		["fire:permanent_flame"]=10,
+	},
+	dirt="default:stone",
+	grass="default:stone",
+	sand="default:lava_source",
+	water="default:lava_source",
+	map={octaves=3,persist=0.6,lacunarity=2},
+	node={description="Hot"},
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:torch","default:mese","default:torch",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	}
+})
 
 
-	multidimensions.register_dimension("water",{
-		dirt="default:water_source",
-		grass="default:water_source",
-		sand="default:stone",
-		node={description="Water"},
-		flatland=1,
-		stone="default:water_source",
-		air="default:water_source",
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:sand","default:mese","default:sand",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		}
-	})
+multidimensions.register_dimension("water",{
+	dirt="default:water_source",
+	grass="default:water_source",
+	sand="default:stone",
+	node={description="Water"},
+	flatland=1,
+	stone="default:water_source",
+	air="default:water_source",
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:sand","default:mese","default:sand",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	}
+})
 
-	multidimensions.register_dimension("sandstone",{
-		dirt="default:sandstone",
-		grass="default:sandstone",
-		sand="default:sandstone",
-		node={description="Sandstone"},
-		stone="default:sandstone",
-		enable_water=false,
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:sandstone","default:mese","default:sandstone",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		}
-	})
+multidimensions.register_dimension("sandstone",{
+	dirt="default:sandstone",
+	grass="default:sandstone",
+	sand="default:sandstone",
+	node={description="Sandstone"},
+	stone="default:sandstone",
+	enable_water=false,
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:sandstone","default:mese","default:sandstone",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	}
+})
 
-	multidimensions.register_dimension("flatland",{
-		enable_water=false,
-		dirt="default:stone",
-		flatland=true,
-		craft = {
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-			{"default:dirt","default:mese","default:dirt",},
-			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		}
-	})
+multidimensions.register_dimension("flatland",{
+	enable_water=false,
+	dirt="default:stone",
+	flatland=true,
+	craft = {
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		{"default:dirt","default:mese","default:dirt",},
+		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+	}
+})
 
-	minetest.register_lbm({
-		name = "multidimensions:lbm",
-		run_at_every_load = true,
-		nodenames = {"group:multidimensions_tree"},
-		action = function(pos, node)
-			minetest.set_node(pos, {name = "air"})
-			local tree=""
-			if node.name=="multidimensions:tree" then
-				tree=minetest.get_modpath("default") .. "/schematics/apple_tree.mts"
-			elseif node.name=="multidimensions:pine_tree" then
-				tree=minetest.get_modpath("default") .. "/schematics/pine_tree.mts"
-			elseif node.name=="multidimensions:pine_treesnow" then
-				tree=minetest.get_modpath("default") .. "/schematics/snowy_pine_tree_from_sapling.mts"
-			elseif node.name=="multidimensions:jungle_tree" then
-				tree=minetest.get_modpath("default") .. "/schematics/jungle_tree.mts"
-			elseif node.name=="multidimensions:aspen_tree" then
-				tree=minetest.get_modpath("default") .. "/schematics/aspen_tree.mts"
-			elseif node.name=="multidimensions:acacia_tree" then
-				tree=minetest.get_modpath("default") .. "/schematics/acacia_tree.mts"
-			end
-			minetest.place_schematic({x=pos.x,y=pos.y,z=pos.z}, tree, "random", {}, true)
-		end,
-	})
-end
+minetest.register_lbm({
+	name = "multidimensions:lbm",
+	run_at_every_load = true,
+	nodenames = {"group:multidimensions_tree"},
+	action = function(pos, node)
+		minetest.set_node(pos, {name = "air"})
+		local tree=""
+		if node.name=="multidimensions:tree" then
+			tree=minetest.get_modpath("default") .. "/schematics/apple_tree.mts"
+		elseif node.name=="multidimensions:pine_tree" then
+			tree=minetest.get_modpath("default") .. "/schematics/pine_tree.mts"
+		elseif node.name=="multidimensions:pine_treesnow" then
+			tree=minetest.get_modpath("default") .. "/schematics/snowy_pine_tree_from_sapling.mts"
+		elseif node.name=="multidimensions:jungle_tree" then
+			tree=minetest.get_modpath("default") .. "/schematics/jungle_tree.mts"
+		elseif node.name=="multidimensions:aspen_tree" then
+			tree=minetest.get_modpath("default") .. "/schematics/aspen_tree.mts"
+		elseif node.name=="multidimensions:acacia_tree" then
+			tree=minetest.get_modpath("default") .. "/schematics/acacia_tree.mts"
+		end
+		minetest.place_schematic({x=pos.x,y=pos.y,z=pos.z}, tree, "random", {}, true)
+	end,
+})

--- a/dimensions.lua
+++ b/dimensions.lua
@@ -35,209 +35,211 @@ minetest.register_node("multidimensions:jungle_tree", {drawtype="airlike",groups
 minetest.register_node("multidimensions:aspen_tree", {drawtype="airlike",groups = {multidimensions_tree=1,not_in_creative_inventory=1},})
 minetest.register_node("multidimensions:acacia_tree", {drawtype="airlike",groups = {multidimensions_tree=1,not_in_creative_inventory=1},})
 
-multidimensions.register_dimension("earthlike1",{
-	ground_ores = table.copy(plants),
-	stone_ores = table.copy(ores),
-	sand_ores={["default:clay"]={chunk=2,chance=5000}},
-	grass_ores={
-		["default:dirt_with_snow"]={chance=1,max_heat=20},
-	},
-	water_ores={
-		["default:ice"]={chance=1,max_heat=20},
-	},
-	node={description="Alternative earth"},
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:wood","default:mese","default:wood",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	}
-})
+if minetest.get_modpath("default") then
+	multidimensions.register_dimension("earthlike1",{
+		ground_ores = table.copy(plants),
+		stone_ores = table.copy(ores),
+		sand_ores={["default:clay"]={chunk=2,chance=5000}},
+		grass_ores={
+			["default:dirt_with_snow"]={chance=1,max_heat=20},
+		},
+		water_ores={
+			["default:ice"]={chance=1,max_heat=20},
+		},
+		node={description="Alternative earth"},
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:wood","default:mese","default:wood",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		}
+	})
 
-multidimensions.register_dimension("earthlike2",{
-	ground_ores = table.copy(plants),
-	stone_ores = table.copy(ores),
-	sand_ores={["default:clay"]={chunk=2,chance=5000}},
-	node={description="Alternative earth 2"},
-	map={spread={x=20,y=18,z=20}},
-	ground_limit=550,
-	gravity=0.5,
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:aspen_wood","default:mese","default:aspen_wood",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	}
-})
+	multidimensions.register_dimension("earthlike2",{
+		ground_ores = table.copy(plants),
+		stone_ores = table.copy(ores),
+		sand_ores={["default:clay"]={chunk=2,chance=5000}},
+		node={description="Alternative earth 2"},
+		map={spread={x=20,y=18,z=20}},
+		ground_limit=550,
+		gravity=0.5,
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:aspen_wood","default:mese","default:aspen_wood",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		}
+	})
 
-multidimensions.register_dimension("floatandlike",{
-	ground_ores = table.copy(plants),
-	stone_ores = table.copy(ores),
-	node={description="Alternative floatand"},
-	ground_limit=550,
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:dirt","default:mese","default:dirt",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	},
-	map={
-		spread={x=30,y=30,z=30},
-		octaves=3,
-		persist=0.2,
-		lacunarity=2,
-		flags="eased",
-	},
-	terrain_density=0.2,
-	enable_water=false,
-	self={
-		blocking="multidimensions:blocking",
-		killing = "multidimensions:killing",
-	},
-	on_generate=function(self,data,id,area,x,y,z)
-		if y <= self.dirt_start-70 then
-			data[id] = self.killing
-		elseif y <= self.dirt_start-100 then
-			data[id] = self.blocking
-		elseif y <= self.dirt_start+5 then
-			data[id] = self.air
-		else
-			return
-		end
-		return data
-	end,
-})
-
-
-
-multidimensions.register_dimension("savana",{
-	ground_ores = {
-		["default:dry_shrub"]=50,
-		["default:dry_grass_4"]=10,
-		["multidimensions:acacia_tree"]=5000,
-		["multidimensions:jungle_tree"]=7000,
-	},
-	grass="default:dirt_with_dry_grass",
-	stone_ores = table.copy(ores),
-	sand_ores={["default:clay"]=100},
-	node={description="Savana"},
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:acacia","default:mese","default:acacia",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	}
-})
-
-multidimensions.register_dimension("cold",{
-	ground_ores = {
-		["default:snow"]=100,
-		["multidimensions:pine_treesnow"]=8000,
-	},
-	dirt="default:snowblock",
-	grass="default:snowblock",
-	water="default:ice",
-	stone="default:ice",
-	sand="default:ice",
-	node={description="cold"},
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:aspen_wood","default:mese","default:aspen_wood",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	}
-})
-
-multidimensions.register_dimension("desert",{
-	dirt="default:desert_sand",
-	grass="default:desert_sand",
-	stone="default:desert_stone",
-	sand="default:desert_sand",
-	node={description="desert"},
-	enable_water=false,
-	gravity=0.4,
-	map={octaves=2,persist=0.3,lacunarity=2},
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:desert_stone","default:mese","default:desert_stone",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	},
-	sky={{r=219, g=168, b=117},"plain",{}},
-})
-
-multidimensions.register_dimension("hot",{
-	ground_ores = {
-		["fire:permanent_flame"]=10,
-	},
-	dirt="default:stone",
-	grass="default:stone",
-	sand="default:lava_source",
-	water="default:lava_source",
-	map={octaves=3,persist=0.6,lacunarity=2},
-	node={description="Hot"},
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:torch","default:mese","default:torch",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	}
-})
+	multidimensions.register_dimension("floatandlike",{
+		ground_ores = table.copy(plants),
+		stone_ores = table.copy(ores),
+		node={description="Alternative floatand"},
+		ground_limit=550,
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:dirt","default:mese","default:dirt",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		},
+		map={
+			spread={x=30,y=30,z=30},
+			octaves=3,
+			persist=0.2,
+			lacunarity=2,
+			flags="eased",
+		},
+		terrain_density=0.2,
+		enable_water=false,
+		self={
+			blocking="multidimensions:blocking",
+			killing = "multidimensions:killing",
+		},
+		on_generate=function(self,data,id,area,x,y,z)
+			if y <= self.dirt_start-70 then
+				data[id] = self.killing
+			elseif y <= self.dirt_start-100 then
+				data[id] = self.blocking
+			elseif y <= self.dirt_start+5 then
+				data[id] = self.air
+			else
+				return
+			end
+			return data
+		end,
+	})
 
 
-multidimensions.register_dimension("water",{
-	dirt="default:water_source",
-	grass="default:water_source",
-	sand="default:stone",
-	node={description="Water"},
-	flatland=1,
-	stone="default:water_source",
-	air="default:water_source",
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:sand","default:mese","default:sand",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	}
-})
 
-multidimensions.register_dimension("sandstone",{
-	dirt="default:sandstone",
-	grass="default:sandstone",
-	sand="default:sandstone",
-	node={description="Sandstone"},
-	stone="default:sandstone",
-	enable_water=false,
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:sandstone","default:mese","default:sandstone",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	}
-})
+	multidimensions.register_dimension("savana",{
+		ground_ores = {
+			["default:dry_shrub"]=50,
+			["default:dry_grass_4"]=10,
+			["multidimensions:acacia_tree"]=5000,
+			["multidimensions:jungle_tree"]=7000,
+		},
+		grass="default:dirt_with_dry_grass",
+		stone_ores = table.copy(ores),
+		sand_ores={["default:clay"]=100},
+		node={description="Savana"},
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:acacia","default:mese","default:acacia",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		}
+	})
 
-multidimensions.register_dimension("flatland",{
-	enable_water=false,
-	dirt="default:stone",
-	flatland=true,
-	craft = {
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-		{"default:dirt","default:mese","default:dirt",},
-		{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
-	}
-})
+	multidimensions.register_dimension("cold",{
+		ground_ores = {
+			["default:snow"]=100,
+			["multidimensions:pine_treesnow"]=8000,
+		},
+		dirt="default:snowblock",
+		grass="default:snowblock",
+		water="default:ice",
+		stone="default:ice",
+		sand="default:ice",
+		node={description="cold"},
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:aspen_wood","default:mese","default:aspen_wood",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		}
+	})
 
-minetest.register_lbm({
-	name = "multidimensions:lbm",
-	run_at_every_load = true,
-	nodenames = {"group:multidimensions_tree"},
-	action = function(pos, node)
-		minetest.set_node(pos, {name = "air"})
-		local tree=""
-		if node.name=="multidimensions:tree" then
-			tree=minetest.get_modpath("default") .. "/schematics/apple_tree.mts"
-		elseif node.name=="multidimensions:pine_tree" then
-			tree=minetest.get_modpath("default") .. "/schematics/pine_tree.mts"
-		elseif node.name=="multidimensions:pine_treesnow" then
-			tree=minetest.get_modpath("default") .. "/schematics/snowy_pine_tree_from_sapling.mts"
-		elseif node.name=="multidimensions:jungle_tree" then
-			tree=minetest.get_modpath("default") .. "/schematics/jungle_tree.mts"
-		elseif node.name=="multidimensions:aspen_tree" then
-			tree=minetest.get_modpath("default") .. "/schematics/aspen_tree.mts"
-		elseif node.name=="multidimensions:acacia_tree" then
-			tree=minetest.get_modpath("default") .. "/schematics/acacia_tree.mts"
-		end
-		minetest.place_schematic({x=pos.x,y=pos.y,z=pos.z}, tree, "random", {}, true)
-	end,
-})
+	multidimensions.register_dimension("desert",{
+		dirt="default:desert_sand",
+		grass="default:desert_sand",
+		stone="default:desert_stone",
+		sand="default:desert_sand",
+		node={description="desert"},
+		enable_water=false,
+		gravity=0.4,
+		map={octaves=2,persist=0.3,lacunarity=2},
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:desert_stone","default:mese","default:desert_stone",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		},
+		sky={{r=219, g=168, b=117},"plain",{}},
+	})
+
+	multidimensions.register_dimension("hot",{
+		ground_ores = {
+			["fire:permanent_flame"]=10,
+		},
+		dirt="default:stone",
+		grass="default:stone",
+		sand="default:lava_source",
+		water="default:lava_source",
+		map={octaves=3,persist=0.6,lacunarity=2},
+		node={description="Hot"},
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:torch","default:mese","default:torch",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		}
+	})
+
+
+	multidimensions.register_dimension("water",{
+		dirt="default:water_source",
+		grass="default:water_source",
+		sand="default:stone",
+		node={description="Water"},
+		flatland=1,
+		stone="default:water_source",
+		air="default:water_source",
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:sand","default:mese","default:sand",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		}
+	})
+
+	multidimensions.register_dimension("sandstone",{
+		dirt="default:sandstone",
+		grass="default:sandstone",
+		sand="default:sandstone",
+		node={description="Sandstone"},
+		stone="default:sandstone",
+		enable_water=false,
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:sandstone","default:mese","default:sandstone",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		}
+	})
+
+	multidimensions.register_dimension("flatland",{
+		enable_water=false,
+		dirt="default:stone",
+		flatland=true,
+		craft = {
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+			{"default:dirt","default:mese","default:dirt",},
+			{"default:obsidianbrick", "default:steel_ingot", "default:obsidianbrick"},
+		}
+	})
+
+	minetest.register_lbm({
+		name = "multidimensions:lbm",
+		run_at_every_load = true,
+		nodenames = {"group:multidimensions_tree"},
+		action = function(pos, node)
+			minetest.set_node(pos, {name = "air"})
+			local tree=""
+			if node.name=="multidimensions:tree" then
+				tree=minetest.get_modpath("default") .. "/schematics/apple_tree.mts"
+			elseif node.name=="multidimensions:pine_tree" then
+				tree=minetest.get_modpath("default") .. "/schematics/pine_tree.mts"
+			elseif node.name=="multidimensions:pine_treesnow" then
+				tree=minetest.get_modpath("default") .. "/schematics/snowy_pine_tree_from_sapling.mts"
+			elseif node.name=="multidimensions:jungle_tree" then
+				tree=minetest.get_modpath("default") .. "/schematics/jungle_tree.mts"
+			elseif node.name=="multidimensions:aspen_tree" then
+				tree=minetest.get_modpath("default") .. "/schematics/aspen_tree.mts"
+			elseif node.name=="multidimensions:acacia_tree" then
+				tree=minetest.get_modpath("default") .. "/schematics/acacia_tree.mts"
+			end
+			minetest.place_schematic({x=pos.x,y=pos.y,z=pos.z}, tree, "random", {}, true)
+		end,
+	})
+end

--- a/init.lua
+++ b/init.lua
@@ -29,5 +29,9 @@ multidimensions={
 }
 
 dofile(minetest.get_modpath("multidimensions") .. "/api.lua")
-dofile(minetest.get_modpath("multidimensions") .. "/dimensions.lua")
+
+if minetest.get_modpath("default") then
+	dofile(minetest.get_modpath("multidimensions") .. "/dimensions.lua")
+end
+
 dofile(minetest.get_modpath("multidimensions") .. "/tools.lua")

--- a/mod.conf
+++ b/mod.conf
@@ -1,24 +1,4 @@
 name = multidimensions
 description = Multi dimensions
 optional_depends = beds, sethome, flowers, fire, default
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,7 +1,6 @@
 name = multidimensions
 description = Multi dimensions
-depends = default
-optional_depends = beds, sethome, flowers, fire
+optional_depends = beds, sethome, flowers, fire, default
 
 
 

--- a/tools.lua
+++ b/tools.lua
@@ -227,3 +227,60 @@ minetest.register_globalstep(function(dtime)
 		end
 	end
 end)
+
+if minetest.get_modpath("default") then
+	minetest.register_node("multidimensions:teleporter0", {
+		description = "Teleport to dimension earth",
+		tiles = {"default_steel_block.png","default_steel_block.png","default_mese_block.png^[colorize:#1e6600cc"},
+		groups = {choppy=2,oddly_breakable_by_hand=1},
+		is_ground_content = false,
+		sounds = (default and default.node_sound_wood_defaults()) or nil,
+		after_place_node = function(pos, placer, itemstack)
+			local meta=minetest.get_meta(pos)
+			meta:set_string("owner",placer:get_player_name())
+			meta:set_string("infotext","Teleport to dimension earth")
+		end,
+		on_rightclick = function(pos, node, player, itemstack, pointed_thing)
+			local owner=minetest.get_meta(pos):get_string("owner")
+			local pos2={x=pos.x,y=0,z=pos.z}
+			if minetest.is_protected(pos2, owner)==false then
+				multidimensions.move(player,pos2)
+			end
+		end,
+		mesecons = {effector = {
+			action_on = function (pos, node)
+			local owner=minetest.get_meta(pos):get_string("owner")
+			local pos2={x=pos.x,y=0,z=pos.z}
+			for i, ob in pairs(minetest.get_objects_inside_radius(pos, 5)) do
+				multidimensions.move(ob,pos2)
+			end
+			return false
+		end}},
+	})
+
+	minetest.register_node("multidimensions:teleporterre", {
+		description = "Teleport back",
+		tiles = {"default_steel_block.png"},
+		groups = {cracky=3},
+		is_ground_content = false,
+		sounds = (default and default.node_sound_wood_defaults()) or nil,
+		drop = "default:cobble",
+		on_rightclick = function(pos, node, player, itemstack, pointed_thing)
+			local p = minetest.get_meta(pos):get_string("pos")
+			if p == "" then
+				minetest.remove_node(pos)
+				return
+			end
+			multidimensions.move(player,minetest.string_to_pos(p),nil,true)
+		end,
+		mesecons = {effector = {
+			action_on = function (pos, node)
+			local owner=minetest.get_meta(pos):get_string("owner")
+			local pos2={x=pos.x,y=0,z=pos.z}
+			for i, ob in pairs(minetest.get_objects_inside_radius(pos, 5)) do
+				multidimensions.move(ob,pos2)
+			end
+			return false
+		end}},
+	})
+end

--- a/tools.lua
+++ b/tools.lua
@@ -161,7 +161,9 @@ multidimensions.move=function(object,pos,set_re)
 		return
 	end
 
-	minetest.set_node({x=pos.x,y=pos.y-2,z=pos.z},{name="default:cobble"})
+	if minetest.get_modpath("default") then
+		minetest.set_node({x=pos.x,y=pos.y-2,z=pos.z},{name="default:cobble"})
+	end
 	minetest.after(1, function(pos,object,move,set_re)
 		for i=1,100,1 do
 			local nname=minetest.get_node(pos).name
@@ -179,12 +181,14 @@ multidimensions.move=function(object,pos,set_re)
 			end
 		end
 		pos.y = pos.y - 2
-		local reg = minetest.registered_nodes[minetest.get_node(pos).name]
-		if reg == nil or reg.walkable == false or reg.name == "default:cobble" then
-			for x = -2,2,1 do
-			for z = -2,2,1 do
-				minetest.set_node({x=pos.x+x,y=pos.y,z=pos.z+z},{name="default:cobble"})
-			end
+		if minetest.get_modpath("default") then
+			local reg = minetest.registered_nodes[minetest.get_node(pos).name]
+			if reg == nil or reg.walkable == false or reg.name == "default:cobble" then
+				for x = -2,2,1 do
+				for z = -2,2,1 do
+					minetest.set_node({x=pos.x+x,y=pos.y,z=pos.z+z},{name="default:cobble"})
+				end
+				end
 			end
 		end
 	end, pos,object,move,set_re)
@@ -205,12 +209,14 @@ multidimensions.move=function(object,pos,set_re)
 			end
 		end
 		pos.y = pos.y - 2
-		local reg = minetest.registered_nodes[minetest.get_node(pos).name]
-		if reg == nil or reg.walkable == false or reg.name == "default:cobble" then
-			for x = -2,2,1 do
-			for z = -2,2,1 do
-				minetest.set_node({x=pos.x+x,y=pos.y,z=pos.z+z},{name="default:cobble"})
-			end
+		if minetest.get_modpath("default") then
+			local reg = minetest.registered_nodes[minetest.get_node(pos).name]
+			if reg == nil or reg.walkable == false or reg.name == "default:cobble" then
+				for x = -2,2,1 do
+				for z = -2,2,1 do
+					minetest.set_node({x=pos.x+x,y=pos.y,z=pos.z+z},{name="default:cobble"})
+				end
+				end
 			end
 		end
 	end, pos,object,move,set_re)
@@ -228,59 +234,62 @@ minetest.register_globalstep(function(dtime)
 	end
 end)
 
+local tp_tiles = "^[colorize:green"
 if minetest.get_modpath("default") then
-	minetest.register_node("multidimensions:teleporter0", {
-		description = "Teleport to dimension earth",
-		tiles = {"default_steel_block.png","default_steel_block.png","default_mese_block.png^[colorize:#1e6600cc"},
-		groups = {choppy=2,oddly_breakable_by_hand=1},
-		is_ground_content = false,
-		sounds = (default and default.node_sound_wood_defaults()) or nil,
-		after_place_node = function(pos, placer, itemstack)
-			local meta=minetest.get_meta(pos)
-			meta:set_string("owner",placer:get_player_name())
-			meta:set_string("infotext","Teleport to dimension earth")
-		end,
-		on_rightclick = function(pos, node, player, itemstack, pointed_thing)
-			local owner=minetest.get_meta(pos):get_string("owner")
-			local pos2={x=pos.x,y=0,z=pos.z}
-			if minetest.is_protected(pos2, owner)==false then
-				multidimensions.move(player,pos2)
-			end
-		end,
-		mesecons = {effector = {
-			action_on = function (pos, node)
-			local owner=minetest.get_meta(pos):get_string("owner")
-			local pos2={x=pos.x,y=0,z=pos.z}
-			for i, ob in pairs(minetest.get_objects_inside_radius(pos, 5)) do
-				multidimensions.move(ob,pos2)
-			end
-			return false
-		end}},
-	})
-
-	minetest.register_node("multidimensions:teleporterre", {
-		description = "Teleport back",
-		tiles = {"default_steel_block.png"},
-		groups = {cracky=3},
-		is_ground_content = false,
-		sounds = (default and default.node_sound_wood_defaults()) or nil,
-		drop = "default:cobble",
-		on_rightclick = function(pos, node, player, itemstack, pointed_thing)
-			local p = minetest.get_meta(pos):get_string("pos")
-			if p == "" then
-				minetest.remove_node(pos)
-				return
-			end
-			multidimensions.move(player,minetest.string_to_pos(p),nil,true)
-		end,
-		mesecons = {effector = {
-			action_on = function (pos, node)
-			local owner=minetest.get_meta(pos):get_string("owner")
-			local pos2={x=pos.x,y=0,z=pos.z}
-			for i, ob in pairs(minetest.get_objects_inside_radius(pos, 5)) do
-				multidimensions.move(ob,pos2)
-			end
-			return false
-		end}},
-	})
+	tp_tiles = "default_steel_block.png"
 end
+
+minetest.register_node("multidimensions:teleporter0", {
+	description = "Teleport to dimension earth",
+	tiles = { tp_tiles, tp_tiles, tp_tiles.."^[colorize:#1e6600cc" },
+	groups = {choppy=2,oddly_breakable_by_hand=1},
+	is_ground_content = false,
+	sounds = (default and default.node_sound_wood_defaults()) or nil,
+	after_place_node = function(pos, placer, itemstack)
+		local meta=minetest.get_meta(pos)
+		meta:set_string("owner",placer:get_player_name())
+		meta:set_string("infotext","Teleport to dimension earth")
+	end,
+	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
+		local owner=minetest.get_meta(pos):get_string("owner")
+		local pos2={x=pos.x,y=0,z=pos.z}
+		if minetest.is_protected(pos2, owner)==false then
+			multidimensions.move(player,pos2)
+		end
+	end,
+	mesecons = {effector = {
+		action_on = function (pos, node)
+		local owner=minetest.get_meta(pos):get_string("owner")
+		local pos2={x=pos.x,y=0,z=pos.z}
+		for i, ob in pairs(minetest.get_objects_inside_radius(pos, 5)) do
+			multidimensions.move(ob,pos2)
+		end
+		return false
+	end}},
+})
+
+minetest.register_node("multidimensions:teleporterre", {
+	description = "Teleport back",
+	tiles = tp_tiles,
+	groups = {cracky=3},
+	is_ground_content = false,
+	sounds = (default and default.node_sound_wood_defaults()) or nil,
+	drop = minetest.get_modpath("default") and "default:cobble" or "",
+	on_rightclick = function(pos, node, player, itemstack, pointed_thing)
+		local p = minetest.get_meta(pos):get_string("pos")
+		if p == "" then
+			minetest.remove_node(pos)
+			return
+		end
+		multidimensions.move(player,minetest.string_to_pos(p),nil,true)
+	end,
+	mesecons = {effector = {
+		action_on = function (pos, node)
+		local owner=minetest.get_meta(pos):get_string("owner")
+		local pos2={x=pos.x,y=0,z=pos.z}
+		for i, ob in pairs(minetest.get_objects_inside_radius(pos, 5)) do
+			multidimensions.move(ob,pos2)
+		end
+		return false
+	end}},
+})

--- a/tools.lua
+++ b/tools.lua
@@ -144,7 +144,7 @@ multidimensions.apply_dimension=function(player)
 		end
 	end
 	player:set_physics_override({gravity=1})
-	player:set_sky(nil,"regular",nil)
+	player: set_sky({type="regular"})
 	multidimensions.player_pos[name] = {
 		y1 = multidimensions.earth.under,
 		y2 = multidimensions.earth.above,


### PR DESCRIPTION
Does not change the current behavior in minetest game but makes all default specific code (including the dimension registrations) conditional on default being present and moves the dependency on default to optional_depends.

This is to make it possible to use the mutli dimensions api in other games than mtg-derivates.

Also fixes some whitespace messes and windows line endings.

**Testing:**
* Verify the mod still works like before in minetest_game 
* Verify the mod can be loaded in games that do not provide default (e.g. void game)